### PR TITLE
Refactor: Update default translation ID to 20 and use constant

### DIFF
--- a/src/components/api-test.tsx
+++ b/src/components/api-test.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import axios from 'axios';
 import { useMemo, useState } from 'react';
+import { DEFAULT_TRANSLATION_ID } from '../data/constants';
 import { Button, Collapse as CollapseAntd } from 'antd';
 import { styled } from 'styled-components';
 
@@ -94,7 +95,7 @@ const initValues = [
 	},
 	{
 		id: 3,
-		url: 'https://api.quran.com/api/v4/quran/translations/131',
+		url: `https://api.quran.com/api/v4/quran/translations/${DEFAULT_TRANSLATION_ID}`,
 	},
 	{
 		id: 4,

--- a/src/components/sura-list/results/translation-selector.tsx
+++ b/src/components/sura-list/results/translation-selector.tsx
@@ -4,6 +4,7 @@ import {
 	TranslationItem,
 	useTranslations,
 } from 'data/use-translations';
+import { DEFAULT_TRANSLATION_ID } from 'data/constants';
 import { useEffect, useMemo, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useSearchParams } from 'react-router-dom';
@@ -65,7 +66,7 @@ const LanguageTabs = ({ data }: LanguagesProps) => {
 	>({});
 
 	const selectedTrId = useMemo(
-		() => +(searchParams.get('tr') || '131'),
+		() => +(searchParams.get('tr') || DEFAULT_TRANSLATION_ID),
 		[searchParams]
 	);
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,1 +1,2 @@
 export const BISMI = 'بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ';
+export const DEFAULT_TRANSLATION_ID = 20;

--- a/src/data/use-verses.ts
+++ b/src/data/use-verses.ts
@@ -2,6 +2,7 @@ import { useQuery, UseQueryResult } from 'react-query';
 import axios from 'axios';
 import { TransaltionItem, Verse } from '../types';
 import { useSearchParams } from 'react-router-dom';
+import { DEFAULT_TRANSLATION_ID } from './constants';
 
 type VerseData = {
 	verses: Verse[];
@@ -31,7 +32,8 @@ export const useVerses = (): UseQueryResult<{
 }> => {
 	const [searchParams] = useSearchParams();
 
-	const translationId = searchParams.get('tr') || '131';
+	const translationId =
+		searchParams.get('tr') || String(DEFAULT_TRANSLATION_ID);
 
 	return useQuery(
 		['quran-verses', translationId],


### PR DESCRIPTION
- Changed the default translation ID from 131 to 20.
- Introduced `DEFAULT_TRANSLATION_ID` constant in `src/data/constants.ts`.
- Replaced hardcoded occurrences of the old ID with the new constant in relevant files:
    - src/components/sura-list/results/translation-selector.tsx
    - src/components/api-test.tsx
    - src/data/use-verses.ts