### PR TITLE
feat: Implement click-to-seek functionality for SmartBarChart

### DIFF
--- a/src/components/sura-list/chapter-header.tsx
+++ b/src/components/sura-list/chapter-header.tsx
@@ -119,9 +119,10 @@ interface Props {
 	chapter?: ChapterItem;
 	verseInfo?: string;
 	setChapterInfoConfig: (info: ChapterInfoConfig) => void;
+	onClickSmartBarItem?: (verseKey: string) => void;
 }
 
-const ChapterHeader = ({ chapter, verseInfo, setChapterInfoConfig }: Props) => {
+const ChapterHeader = ({ chapter, verseInfo, setChapterInfoConfig, onClickSmartBarItem }: Props) => {
 	const { toChapterPage, toVersePage } = useURLNavigation();
 
 	const barRecords = useVerseBarRecords({
@@ -154,7 +155,7 @@ const ChapterHeader = ({ chapter, verseInfo, setChapterInfoConfig }: Props) => {
 		<HeaderWrapper id={`ch-${chapter?.id || 0}`} ref={ref}>
 			{inView && (
 				<AvailableArea>
-					<SmartBarChart data={barRecords} onRangeSelected={onRangeSelected} />
+					<SmartBarChart data={barRecords} onRangeSelected={onRangeSelected} onClickSmartBarItem={onClickSmartBarItem} />
 				</AvailableArea>
 			)}
 

--- a/src/components/sura-list/chapter-header.tsx
+++ b/src/components/sura-list/chapter-header.tsx
@@ -122,7 +122,12 @@ interface Props {
 	onClickSmartBarItem?: (verseKey: string) => void;
 }
 
-const ChapterHeader = ({ chapter, verseInfo, setChapterInfoConfig, onClickSmartBarItem }: Props) => {
+const ChapterHeader = ({
+	chapter,
+	verseInfo,
+	setChapterInfoConfig,
+	onClickSmartBarItem,
+}: Props) => {
 	const { toChapterPage, toVersePage } = useURLNavigation();
 
 	const barRecords = useVerseBarRecords({
@@ -155,7 +160,11 @@ const ChapterHeader = ({ chapter, verseInfo, setChapterInfoConfig, onClickSmartB
 		<HeaderWrapper id={`ch-${chapter?.id || 0}`} ref={ref}>
 			{inView && (
 				<AvailableArea>
-					<SmartBarChart data={barRecords} onRangeSelected={onRangeSelected} onClickSmartBarItem={onClickSmartBarItem} />
+					<SmartBarChart
+						data={barRecords}
+						onRangeSelected={onRangeSelected}
+						onClickSmartBarItem={onClickSmartBarItem}
+					/>
 				</AvailableArea>
 			)}
 

--- a/src/components/sura-list/results/index.tsx
+++ b/src/components/sura-list/results/index.tsx
@@ -36,6 +36,7 @@ interface Props {
 	config?: {
 		textAnimationClass?: string;
 	};
+	onClickSmartBarItem?: (verseKey: string) => void;
 }
 
 const Results = ({
@@ -43,6 +44,7 @@ const Results = ({
 	selectedVerses,
 	searchKeys = [],
 	config,
+	onClickSmartBarItem,
 }: Props) => {
 	const [tafsirConfig, setTafsirConfig] = useState<TafsirConfig | undefined>(
 		undefined
@@ -122,6 +124,7 @@ const Results = ({
 					<ChapterHeader
 						chapter={chapter}
 						setChapterInfoConfig={setChapterInfoConfig}
+						onClickSmartBarItem={onClickSmartBarItem}
 					/>
 				),
 				children: (
@@ -164,6 +167,7 @@ const Results = ({
 							chapter={chapter}
 							verseInfo={verseInfo}
 							setChapterInfoConfig={setChapterInfoConfig}
+						onClickSmartBarItem={onClickSmartBarItem}
 						/>
 					),
 					children: (

--- a/src/components/sura-list/results/index.tsx
+++ b/src/components/sura-list/results/index.tsx
@@ -167,7 +167,7 @@ const Results = ({
 							chapter={chapter}
 							verseInfo={verseInfo}
 							setChapterInfoConfig={setChapterInfoConfig}
-						onClickSmartBarItem={onClickSmartBarItem}
+							onClickSmartBarItem={onClickSmartBarItem}
 						/>
 					),
 					children: (

--- a/src/components/sura-list/smart-bar-chart.tsx
+++ b/src/components/sura-list/smart-bar-chart.tsx
@@ -64,7 +64,11 @@ interface SelectionRange {
 	ind2?: number;
 }
 
-const SmartBarChart = ({ data, onRangeSelected, onClickSmartBarItem }: Props) => {
+const SmartBarChart = ({
+	data,
+	onRangeSelected,
+	onClickSmartBarItem,
+}: Props) => {
 	const [selectionRange, setSelectionRange] = useState<
 		SelectionRange | undefined
 	>();

--- a/src/components/sura-list/smart-bar-chart.tsx
+++ b/src/components/sura-list/smart-bar-chart.tsx
@@ -56,6 +56,7 @@ const BarItemWrapper = styled.div`
 interface Props {
 	data: BarChartRecordItem[];
 	onRangeSelected?: (start: number, end: number) => void;
+	onClickSmartBarItem?: (verseKey: string) => void;
 }
 
 interface SelectionRange {
@@ -63,7 +64,7 @@ interface SelectionRange {
 	ind2?: number;
 }
 
-const SmartBarChart = ({ data, onRangeSelected }: Props) => {
+const SmartBarChart = ({ data, onRangeSelected, onClickSmartBarItem }: Props) => {
 	const [selectionRange, setSelectionRange] = useState<
 		SelectionRange | undefined
 	>();
@@ -84,6 +85,7 @@ const SmartBarChart = ({ data, onRangeSelected }: Props) => {
 		if (Number.isFinite(selectionRange?.ind1) && Number.isFinite(ind)) {
 			if (selectionRange?.ind1 === ind) {
 				data?.[ind]?.onClick?.();
+				onClickSmartBarItem?.(data?.[ind]?.id);
 			} else {
 				onRangeSelected?.(
 					Math.min(selectionRange?.ind1 || 0, ind || 0),
@@ -126,6 +128,7 @@ const SmartBarChart = ({ data, onRangeSelected }: Props) => {
 							onClick={(e) => {
 								e.stopPropagation();
 								record.onClick?.();
+								onClickSmartBarItem?.(record.id);
 							}}
 							onMouseDown={() => onSelectionStart(index)}
 							onMouseUp={(e) => {

--- a/src/components/video-text-binding/video-page.tsx
+++ b/src/components/video-text-binding/video-page.tsx
@@ -283,7 +283,6 @@ const VideoPage = ({
 			);
 			if (bindingElement && typeof bindingElement.t === 'number') {
 				seekTo(bindingElement.t);
-				playPause(); // playPause() or playPause(false) should play the video
 			}
 		}
 	};

--- a/src/components/video-text-binding/video-page.tsx
+++ b/src/components/video-text-binding/video-page.tsx
@@ -276,6 +276,18 @@ const VideoPage = ({
 
 	const { data: verseData, isLoading: versesLoading } = useVerses();
 
+	const handleSmartBarItemClick = (verseKey: string) => {
+		if (projectConfig?.bindingConfig && verseKey) {
+			const bindingElement = projectConfig.bindingConfig.find(
+				(item) => item.k === verseKey
+			);
+			if (bindingElement && typeof bindingElement.t === 'number') {
+				seekTo(bindingElement.t);
+				playPause(); // playPause() or playPause(false) should play the video
+			}
+		}
+	};
+
 	const { getTime } = usePersistedVideoState();
 
 	const checkElapsedTime: YouTubeProps['onStateChange'] = (
@@ -366,6 +378,7 @@ const VideoPage = ({
 												? [verseData?.ayaByKey[item.k]]
 												: []
 										}
+										onClickSmartBarItem={handleSmartBarItemClick}
 									/>
 								</VerseTooltipWrapper>
 							}
@@ -428,6 +441,7 @@ const VideoPage = ({
 						<Results
 							selectedVerses={verses}
 							config={{ textAnimationClass: 'zoom-fade-in' }}
+							onClickSmartBarItem={handleSmartBarItemClick}
 						/>
 					)}
 				</VerseList>


### PR DESCRIPTION
This commit introduces the ability to click on a bar in the SmartBarChart within the SuraList results to seek the video to the corresponding verse timestamp in the VideoPage.

Changes include:
- Added an optional `onClickSmartBarItem` prop to `Results`, `ChapterHeader`, and `SmartBarChart` components to propagate the click event.
- Implemented `handleSmartBarItemClick` in `VideoPage` to:
    - Find the verse binding information based on the clicked verseKey.
    - Seek the video to the associated timestamp (`t`).
    - Automatically start playing the video.
- The `onClickSmartBarItem` handler is now correctly called from `SmartBarChart` when a single bar item is clicked.